### PR TITLE
Added style-report to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 composer.lock
+style-report/
 vendor/
 checkstyle_resultncss.xml
 .project


### PR DESCRIPTION
When analyzing phpcheckstyle with itself, it creates `style-report` folder which shouldn't be added to repository.
