### PR TITLE
Fixed problem with PHP5.5 ::class syntax

### DIFF
--- a/src/PHPCheckstyle/PHPCheckstyle.php
+++ b/src/PHPCheckstyle/PHPCheckstyle.php
@@ -2202,6 +2202,11 @@ class PHPCheckstyle {
 	 * Process a class declaration statement.
 	 */
 	private function _processClassStatement() {
+		$isAfterScopeResolutionOperator = $this->tokenizer->checkPreviousToken(T_DOUBLE_COLON);
+		if ($isAfterScopeResolutionOperator) {
+			return;
+		}
+
 		// Check PHPDoc presence
 		$this->_checkDocExists(T_CLASS);
 		


### PR DESCRIPTION
Fixed problem with `::class` scope resolution syntax, which was described in #9.
Seems to work in my use case, but I'm not sure I haven't accidentally broken anything.
