### PR TITLE
Deduplicate methods into the abstract CheckStyleConfig

### DIFF
--- a/src/PHPCheckstyle/Config/CheckArrayStyleConfig.php
+++ b/src/PHPCheckstyle/Config/CheckArrayStyleConfig.php
@@ -8,9 +8,6 @@ namespace PHPCheckstyle\Config;
  */
 class CheckArrayStyleConfig extends CheckStyleConfig {
 
-	// Array that contains the loaded checks configuration
-	public $myConfig = array();
-
 	/**
 	 * Constructor.
 	 *
@@ -21,160 +18,10 @@ class CheckArrayStyleConfig extends CheckStyleConfig {
 
 		// If the path is a valid file we use it as is
 		if (is_array($configArray)) {
-			$this->myConfig = $configArray;
+			$this->config = $configArray;
 		} else {
 			echo "Config must be an array";
 			exit(0);
-		}
-	}
-
-	/**
-	 * Return a list of items associed with a test.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return array the list of items for this test.
-	 */
-	public function getTestItems($test) {
-		return isset($this->myConfig[$test]['item']) ? $this->myConfig[$test]['item'] : false;
-	}
-
-	/**
-	 * Return a list of items associed with a configuration.
-	 *
-	 * @param String $config
-	 *        	name of the config
-	 * @return array the list of items for this config.
-	 */
-	public function getConfigItems($config) {
-		if (isset($this->myConfig[$config])) {
-			return $this->myConfig[$config];
-		} else {
-			return array();
-		}
-	}
-
-	/**
-	 * Return a list of exceptionfor a test.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return array the list of exceptions for this test.
-	 */
-	public function getTestExceptions($test) {
-		return isset($this->myConfig[$test]['exception']) ? $this->myConfig[$test]['exception'] : false;
-	}
-
-	/**
-	 * Return a true if the test exist, false otherwise.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return Boolean true if test exists.
-	 */
-	public function getTest($test) {
-		return (array_key_exists($test, $this->myConfig));
-	}
-
-	/**
-	 * Return the level of severity of a test.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return the level of severity.
-	 */
-	public function getTestLevel($test) {
-		$ret = WARNING;
-		if (array_key_exists($test, $this->myConfig) && array_key_exists('level', $this->myConfig[$test])) {
-			$ret = $this->myConfig[$test]['level'];
-		}
-
-		if ($ret !== ERROR && $ret !== IGNORE && $ret !== INFO && $ret !== WARNING) {
-			echo "Invalid level for test " . $test . " : " . $ret;
-			$ret = WARNING;
-		}
-
-		return $ret;
-	}
-
-	/**
-	 * Return the regular expression linked to the test.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return the regular expression.
-	 */
-	public function getTestRegExp($test) {
-		$ret = "";
-		if (array_key_exists($test, $this->myConfig) && array_key_exists('regexp', $this->myConfig[$test])) {
-			$ret = $this->myConfig[$test]['regexp'];
-		}
-
-		return $ret;
-	}
-
-	/**
-	 * Return the list of deprecated method and their replacement.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return the list of depecated values.
-	 */
-	public function getTestDeprecations($test) {
-		$ret = "";
-		if (array_key_exists($test, $this->myConfig)) {
-			$ret = $this->myConfig[$test];
-		}
-
-		return $ret;
-	}
-
-	/**
-	 * Return the list of aliases and their replacement.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return the list of replaced values.
-	 */
-	public function getTestAliases($test) {
-		$ret = "";
-		if (array_key_exists($test, $this->myConfig)) {
-			$ret = $this->myConfig[$test];
-		}
-
-		return $ret;
-	}
-
-	/**
-	 * Return the list of replacements.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return the list of replaced values.
-	 */
-	public function getTestReplacements($test) {
-		$ret = "";
-		if (array_key_exists($test, $this->myConfig)) {
-			$ret = $this->myConfig[$test];
-		}
-
-		return $ret;
-	}
-
-	/**
-	 * Return the value of a property
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @param String $property
-	 *        	name of the property
-	 * @return the value.
-	 */
-	public function getTestProperty($test, $property) {
-		if (array_key_exists($test, $this->myConfig) && array_key_exists($property, $this->myConfig[$test])) {
-			return $this->myConfig[$test][$property];
-		} else {
-			return false;
 		}
 	}
 }

--- a/src/PHPCheckstyle/Config/CheckStyleConfig.php
+++ b/src/PHPCheckstyle/Config/CheckStyleConfig.php
@@ -8,14 +8,158 @@ namespace PHPCheckstyle\Config;
  * @SuppressWarnings docBlocks
  */
 abstract class CheckStyleConfig {
-	abstract public function getTestItems($test);
-	abstract public function getConfigItems($config);
-	abstract public function getTestExceptions($test);
-	abstract public function getTest($test);
-	abstract public function getTestLevel($test);
-	abstract public function getTestRegExp($test);
-	abstract public function getTestDeprecations($test);
-	abstract public function getTestAliases($test);
-	abstract public function getTestReplacements($test);
-	abstract public function getTestProperty($test, $property);
+	/**
+	 * Stores the check configuration.
+	 * @var array
+	 */
+	public $config = array();
+
+	/**
+	 * Return a true if the test exist, false otherwise.
+	 *
+	 * @param String $test name of the test
+	 * @return Boolean true if test exists.
+	 */
+	public function getTest($test) {
+		return (array_key_exists(strtolower($test), $this->config));
+	}
+
+	/**
+	 * Return a list of items associed with a test.
+	 *
+	 * @param String $test name of the test
+	 * @return array the list of items for this test.
+	 */
+	public function getTestItems($test) {
+		$test = strtolower($test);
+		return isset($this->config[$test]['item']) ? $this->config[$test]['item'] : false;
+	}
+
+	/**
+	 * Return a list of exceptionfor a test.
+	 *
+	 * @param String $test name of the test
+	 * @return array the list of exceptions for this test.
+	 */
+	public function getTestExceptions($test) {
+		$test = strtolower($test);
+		return isset($this->config[$test]['exception']) ? $this->config[$test]['exception'] : false;
+	}
+
+	/**
+	 * Return a list of items associed with a configuration.
+	 *
+	 * @param String $config name of the config
+	 * @return array the list of items for this config.
+	 */
+	public function getConfigItems($config) {
+		$config = strtolower($config);
+		return isset($this->config[$config]) ? $this->config[$config] : array();
+	}
+
+	/**
+	 * Return the level of severity of a test.
+	 *
+	 * @param String $test name of the test
+	 * @return the level of severity.
+	 */
+	public function getTestLevel($test) {
+		$ret = WARNING;
+
+		$test = strtolower($test);
+
+		if (array_key_exists($test, $this->config) && array_key_exists('level', $this->config[$test])) {
+			$ret = $this->config[$test]['level'];
+		}
+
+		$invalidLevels = array(ERROR, IGNORE, INFO, WARNING);
+
+		if (!in_array($ret, $invalidLevels)) {
+			echo "Invalid level for test " . $test . " : " . $ret;
+			$ret = WARNING;
+		}
+
+		return $ret;
+	}
+
+	/**
+	 * Return the regular expression linked to the test.
+	 *
+	 * @param String $test name of the test
+	 * @return the regular expression.
+	 */
+	public function getTestRegExp($test) {
+		$test = strtolower($test);
+		$ret = "";
+		if (array_key_exists($test, $this->config) && array_key_exists('regexp', $this->config[$test])) {
+			$ret = $this->config[$test]['regexp'];
+		}
+
+		return $ret;
+	}
+
+	/**
+	 * Return the list of deprecated method and their replacement.
+	 *
+	 * @param String $test name of the test
+	 * @return the list of depecated values.
+	 */
+	public function getTestDeprecations($test) {
+		$test = strtolower($test);
+		$ret = "";
+		if (array_key_exists($test, $this->config)) {
+			$ret = $this->config[$test];
+		}
+
+		return $ret;
+	}
+
+	/**
+	 * Return the list of aliases and their replacement.
+	 *
+	 * @param String $test name of the test
+	 * @return the list of replaced values.
+	 */
+	public function getTestAliases($test) {
+		$test = strtolower($test);
+		$ret = "";
+		if (array_key_exists($test, $this->config)) {
+			$ret = $this->config[$test];
+		}
+
+		return $ret;
+	}
+
+	/**
+	 * Return the list of replacements.
+	 *
+	 * @param String $test name of the test
+	 * @return the list of replaced values.
+	 */
+	public function getTestReplacements($test) {
+		$test = strtolower($test);
+		$ret = "";
+		if (array_key_exists($test, $this->config)) {
+			$ret = $this->config[$test];
+		}
+
+		return $ret;
+	}
+
+	/**
+	 * Return the value of a property
+	 *
+	 * @param String $test name of the test
+	 * @param String $property name of the property
+	 * @return the value.
+	 */
+	public function getTestProperty($test, $property) {
+		$test = strtolower($test);
+		$property = strtolower($property);
+		if (array_key_exists($test, $this->config) && array_key_exists($property, $this->config[$test])) {
+			return $this->config[$test][$property];
+		} else {
+			return false;
+		}
+	}
 }

--- a/src/PHPCheckstyle/Config/CheckXMLStyleConfig.php
+++ b/src/PHPCheckstyle/Config/CheckXMLStyleConfig.php
@@ -11,14 +11,8 @@ class CheckXMLStyleConfig extends CheckStyleConfig {
 
 	// The configuration file
 	private $file;
-
-	// Array that contains the loaded checks configuration
-	public $myConfig = array();
-
 	private $currentTest = false;
-
 	private $currentConfig = false;
-
 	private $xmlParser;
 
 	/**
@@ -76,166 +70,10 @@ class CheckXMLStyleConfig extends CheckStyleConfig {
 				$errorLineNo = xml_get_current_line_number($this->xmlParser);
 				$msg = sprintf("Warning: XML error: %s at line %d", $errorString, $errorLineNo);
 				echo $msg;
-				$this->myConfig = array();
+				$this->config = array();
 			}
 
 			$data = fread($fp, 4096);
-		}
-	}
-
-	/**
-	 * Return a list of items associed with a test.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return array the list of items for this test.
-	 */
-	public function getTestItems($test) {
-		$test = strtolower($test);
-		return isset($this->myConfig[$test]['item']) ? $this->myConfig[$test]['item'] : false;
-	}
-
-	/**
-	 * Return a list of items associed with a configuration.
-	 *
-	 * @param String $config
-	 *        	name of the config
-	 * @return array the list of items for this config.
-	 */
-	public function getConfigItems($config) {
-		return $this->myConfig[strtolower($config)];
-	}
-
-	/**
-	 * Return a list of exceptionfor a test.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return array the list of exceptions for this test.
-	 */
-	public function getTestExceptions($test) {
-		$test = strtolower($test);
-		return isset($this->myConfig[$test]['exception']) ? $this->myConfig[$test]['exception'] : false;
-	}
-
-	/**
-	 * Return a true if the test exist, false otherwise.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return Boolean true if test exists.
-	 */
-	public function getTest($test) {
-		$test = strtolower($test);
-		return (array_key_exists($test, $this->myConfig));
-	}
-
-	/**
-	 * Return the level of severity of a test.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return the level of severity.
-	 */
-	public function getTestLevel($test) {
-		$test = strtolower($test);
-		$ret = WARNING;
-		if (array_key_exists($test, $this->myConfig) && array_key_exists('level', $this->myConfig[$test])) {
-			$ret = $this->myConfig[$test]['level'];
-		}
-
-		if ($ret !== ERROR && $ret !== IGNORE && $ret !== INFO && $ret !== WARNING) {
-			echo "Invalid level for test " . $test . " : " . $ret;
-			$ret = WARNING;
-		}
-
-		return $ret;
-	}
-
-	/**
-	 * Return the regular expression linked to the test.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return the regular expression.
-	 */
-	public function getTestRegExp($test) {
-		$test = strtolower($test);
-		$ret = "";
-		if (array_key_exists($test, $this->myConfig) && array_key_exists('regexp', $this->myConfig[$test])) {
-			$ret = $this->myConfig[$test]['regexp'];
-		}
-
-		return $ret;
-	}
-
-	/**
-	 * Return the list of deprecated method and their replacement.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return the list of depecated values.
-	 */
-	public function getTestDeprecations($test) {
-		$test = strtolower($test);
-		$ret = "";
-		if (array_key_exists($test, $this->myConfig)) {
-			$ret = $this->myConfig[$test];
-		}
-
-		return $ret;
-	}
-
-	/**
-	 * Return the list of aliases and their replacement.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return the list of replaced values.
-	 */
-	public function getTestAliases($test) {
-		$test = strtolower($test);
-		$ret = "";
-		if (array_key_exists($test, $this->myConfig)) {
-			$ret = $this->myConfig[$test];
-		}
-
-		return $ret;
-	}
-
-	/**
-	 * Return the list of replacements.
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @return the list of replaced values.
-	 */
-	public function getTestReplacements($test) {
-		$test = strtolower($test);
-		$ret = "";
-		if (array_key_exists($test, $this->myConfig)) {
-			$ret = $this->myConfig[$test];
-		}
-
-		return $ret;
-	}
-
-	/**
-	 * Return the value of a property
-	 *
-	 * @param String $test
-	 *        	name of the test
-	 * @param String $property
-	 *        	name of the property
-	 * @return the value.
-	 */
-	public function getTestProperty($test, $property) {
-		$test = strtolower($test);
-		$property = strtolower($property);
-		if (array_key_exists($test, $this->myConfig) && array_key_exists($property, $this->myConfig[$test])) {
-			return $this->myConfig[$test][$property];
-		} else {
-			return false;
 		}
 	}
 
@@ -257,25 +95,25 @@ class CheckXMLStyleConfig extends CheckStyleConfig {
 			// Case of a configuration property
 			case 'CONFIG':
 				$this->currentConfig = strtolower($attrs['NAME']);
-				$this->myConfig[$this->currentConfig] = array();
+				$this->config[$this->currentConfig] = array();
 				break;
 
 			// Case of a configuration property item
 			case 'CONFIGITEM':
-				$this->myConfig[$this->currentConfig][] = $attrs['VALUE'];
+				$this->config[$this->currentConfig][] = $attrs['VALUE'];
 				break;
 
 			// Case of a test rule
 			case 'TEST':
 				$this->currentTest = strtolower($attrs['NAME']);
-				$this->myConfig[$this->currentTest] = array();
+				$this->config[$this->currentTest] = array();
 
 				if (isset($attrs['LEVEL'])) {
-					$this->myConfig[$this->currentTest]['level'] = $attrs['LEVEL'];
+					$this->config[$this->currentTest]['level'] = $attrs['LEVEL'];
 				}
 
 				if (isset($attrs['REGEXP'])) {
-					$this->myConfig[$this->currentTest]['regexp'] = $attrs['REGEXP'];
+					$this->config[$this->currentTest]['regexp'] = $attrs['REGEXP'];
 				}
 				break;
 
@@ -286,53 +124,53 @@ class CheckXMLStyleConfig extends CheckStyleConfig {
 				if (array_key_exists('VALUE', $attrs)) {
 					$pval = $attrs['VALUE'];
 				}
-				$this->myConfig[$this->currentTest][strtolower($pname)] = $pval;
+				$this->config[$this->currentTest][strtolower($pname)] = $pval;
 				break;
 
 			// Case of a item of a list of values of a rule
 			case 'ITEM':
 				if (isset($attrs['VALUE'])) {
-					$this->myConfig[$this->currentTest]['item'][] = $attrs['VALUE'];
+					$this->config[$this->currentTest]['item'][] = $attrs['VALUE'];
 				}
 				break;
 
 			// Case of an exception to a rule
 			case 'EXCEPTION':
 				if (isset($attrs['VALUE'])) {
-					$this->myConfig[$this->currentTest]['exception'][] = $attrs['VALUE'];
+					$this->config[$this->currentTest]['exception'][] = $attrs['VALUE'];
 				}
 				break;
 
 			// Case of a deprecated function
 			case 'DEPRECATED':
 				if (isset($attrs['OLD'])) {
-					$this->myConfig[$this->currentTest][strtolower($attrs['OLD'])]['old'] = $attrs['OLD'];
+					$this->config[$this->currentTest][strtolower($attrs['OLD'])]['old'] = $attrs['OLD'];
 				}
 				if (isset($attrs['NEW'])) {
-					$this->myConfig[$this->currentTest][strtolower($attrs['OLD'])]['new'] = $attrs['NEW'];
+					$this->config[$this->currentTest][strtolower($attrs['OLD'])]['new'] = $attrs['NEW'];
 				}
 				if (isset($attrs['VERSION'])) {
-					$this->myConfig[$this->currentTest][strtolower($attrs['OLD'])]['version'] = $attrs['VERSION'];
+					$this->config[$this->currentTest][strtolower($attrs['OLD'])]['version'] = $attrs['VERSION'];
 				}
 				break;
 
 			// Case of an alias function
 			case 'ALIAS':
 				if (isset($attrs['OLD'])) {
-					$this->myConfig[$this->currentTest][strtolower($attrs['OLD'])]['old'] = $attrs['OLD'];
+					$this->config[$this->currentTest][strtolower($attrs['OLD'])]['old'] = $attrs['OLD'];
 				}
 				if (isset($attrs['NEW'])) {
-					$this->myConfig[$this->currentTest][strtolower($attrs['OLD'])]['new'] = $attrs['NEW'];
+					$this->config[$this->currentTest][strtolower($attrs['OLD'])]['new'] = $attrs['NEW'];
 				}
 				break;
 
 			// Case of a replacement
 			case 'REPLACEMENT':
 				if (isset($attrs['OLD'])) {
-					$this->myConfig[$this->currentTest][strtolower($attrs['OLD'])]['old'] = $attrs['OLD'];
+					$this->config[$this->currentTest][strtolower($attrs['OLD'])]['old'] = $attrs['OLD'];
 				}
 				if (isset($attrs['NEW'])) {
-					$this->myConfig[$this->currentTest][strtolower($attrs['OLD'])]['new'] = $attrs['NEW'];
+					$this->config[$this->currentTest][strtolower($attrs['OLD'])]['new'] = $attrs['NEW'];
 				}
 				break;
 


### PR DESCRIPTION
Remove some of the duplicated methods in favour of housing them within the abstract class itself. This means that the child Config classes are solely responsible for parsing the configuration.
