### PR TITLE
HTML template will also display when the report was generated at

### DIFF
--- a/html/template/summary.tmpl
+++ b/html/template/summary.tmpl
@@ -2,6 +2,10 @@
 <h1 align="center">Summary</h1>
 <table class="dataTable" align="center">
 	<tr>
+		<td class="tableHead" align="center">Report generated at</td>
+		<td class="tableCell" align="center"><span class="emphasis">%%nb_timestamp%%</span></td>
+	</tr>
+	<tr>
 		<td class="tableHead" align="center">Number of Files Tested</td>
 		<td class="tableCell" align="center"><span class="emphasis">%%nb_files%%</span></td>
 	</tr>

--- a/src/PHPCheckstyle/Reporter/HTMLFormatReporter.php
+++ b/src/PHPCheckstyle/Reporter/HTMLFormatReporter.php
@@ -58,6 +58,7 @@ class HTMLFormatReporter extends Reporter {
 		$values['%%nb_files%%'] = $this->nbfiles - 1;
 		$values['%%nb_files_error%%'] = $this->nbfilesError;
 		$values['%%nb_total_errors%%'] = $this->nbErrors;
+		$values['%%nb_timestamp%%'] = date('Y-m-d H:i:s');
 		$this->writeFragment($this->_fillTemplate($summaryTmpl, $values));
 
 		// Write the list of files


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/246103/4385638/0669ba58-43c7-11e4-8995-7117ade25fcb.png)

Only a simple change, but it's useful for debugging.
