### PR TITLE
Closes #27 - Saner check names

### DIFF
--- a/config/codeigniter.cfg.xml
+++ b/config/codeigniter.cfg.xml
@@ -158,16 +158,16 @@
 	are followed by a space before the opening parenthesis.
 	PEAR standard stipulates this to distinguish it from function calls.
 	-->
-	<test name="spaceAfterControlStmt"/>
+	<test name="spaceAfterControlStatement"/>
 
 	<!-- Check that there is no space after a function name in a function call -->
 	<test name="noSpaceAfterFunctionName" level="info"></test>
 
 	<!-- Check for the (required) presence of a white space after some tokens : "," "}" "-" -->
-	<test name="checkWhiteSpaceAfter"/>
+	<test name="whiteSpaceAfter"/>
 
 	<!-- Check for the (required) presence of a white space before some tokens : "{" "-" -->
-	<test name="checkWhiteSpaceBefore">
+	<test name="whiteSpaceBefore">
 		<exception value=":"/>  <!-- Because of the switch/case -->
 	</test>
 
@@ -184,7 +184,7 @@
 	<!-- Check that the lenght of the line doesn't pass the max value -->
 	<test name="lineLength" level="info">
 		<property name="maxLineLength" value="160"/>
-		<property name="checkHTMLLines" value="false"/>
+		<property name="htmlLines" value="false"/>
 	</test>
 
 	<!-- Checks that the lenght (in lines) of a function doesn't pass the max value -->
@@ -212,7 +212,7 @@
 
 	<!-- Check for prohibited functions -->
 	<!-- @see http://www.php.net/manual/en/indexes.php -->
-	<test name="checkProhibitedFunctions">
+	<test name="prohibitedFunctions">
 		<item value="echo"/>
 		<item value="system"/>
 		<item value="print_r"/>
@@ -234,7 +234,7 @@
 
 	<!-- Check for prohibited tokens -->
 	<!-- @see http://www.php.net/manual/en/tokens.php -->
-	<test name="checkProhibitedTokens">
+	<test name="prohibitedTokens">
 		<item value="T_BAD_CHARACTER"/>
 		<item value="T_DECLARE"/>
 		<item value="T_ENDDECLARE"/>
@@ -262,7 +262,7 @@
 	<test name="defaultValuesOrder"/>
 
 	<!-- Check for silenced errors before function calls (@function) -->
-	<test name="checkSilencedError">
+	<test name="silencedError">
 		<exception value="rename"/> <!-- Exceptions to this rule -->
 		<exception value="mkdir"/>
 		<exception value="chmod"/>
@@ -274,21 +274,21 @@
 	<!-- Avoid passing parameters by reference -->
 	<test name="avoidPassingReferences"/>
 
-	<test name="showTODOs"/>
+	<test name="showTodo"/>
 
 	<!-- Use boolean operators (&&) instead of logical operators (AND) -->
 	<test name="useBooleanOperators"/>
 
 	<!-- Check empty block like if ($a) {} -->
-	<test name="checkEmptyBlock">
+	<test name="emptyBlock">
 		<!--  <exception value="catch"/>  -->
 	</test>
 
 	<!-- Check empty statement ( ;; ) -->
-	<test name="checkEmptyStatement"/>
+	<test name="emptyStatement"/>
 
 	<!-- Check for the presence of heredoc -->
-	<test name="checkHeredoc"/>
+	<test name="heredoc"/>
 
 	<!-- Check for braces around code blocs (if, else, elseif, do, while, for, foreach) -->
 	<test name="needBraces"/>
@@ -306,7 +306,7 @@
 	Avoid using unary operators (++) inside a control statement
 	With the exception of for iterators, all variable incrementation or decrementation should occur in their own toplevel statement to increase readability.
 	-->
-	<test name="checkUnaryOperator">
+	<test name="unaryOperator">
 		<exception value="for"/>
 	</test>
 
@@ -314,7 +314,7 @@
 	With inner assignments it is difficult to see all places where a variable is set.
 	With the exception of for iterators, all assignments should occur in their own toplevel statement to increase readability.
 	-->
-	<test name="checkInnerAssignment">
+	<test name="innerAssignment">
 		<exception value="for"/>
 	</test>
 
@@ -322,23 +322,23 @@
 	<test name="oneClassPerFile"/>
 
 	<!-- Detect empty files -->
-	<test name="checkEmptyFile"/>
+	<test name="emptyFile"/>
 
 	<!--  ****************  -->
 	<!--      Unused        -->
 	<!--  ****************  -->
 
 	<!-- Detect unused private functions (detecting unused public ones is more difficult) -->
-	<test name="checkUnusedPrivateFunctions"/>
+	<test name="unusedPrivateFunctions"/>
 
 	<!-- Detect unused variables -->
-	<test name="checkUnusedVariables"/>
+	<test name="unusedVariables"/>
 
 	<!-- Detect unused function parameters -->
-	<test name="checkUnusedFunctionParameters"/>
+	<test name="unusedFunctionParameters"/>
 
 	<!-- Detect unused code (after return or throw) -->
-	<test name="checkUnusedCode"/>
+	<test name="unusedCode"/>
 
 	<!--  *******************  -->
 	<!--      Optimisation     -->
@@ -353,7 +353,7 @@
 	<!--  *******************  -->
 
 	<!-- Replace deprecated methods -->
-	<test name="checkDeprecation">
+	<test name="deprecation">
 		<deprecated old="call_user_method" new="call_user_func" version="4.1"/>
 		<deprecated old="call_user_method_array" new="call_user_func_array" version="4.1"/>
 		<deprecated old="define_syslog_variables" new="none" version="5.4"/>
@@ -404,7 +404,7 @@
 	<!--  *******************  -->
 
 	<!-- Replace deprecated methods -->
-	<test name="checkAliases">
+	<test name="aliases">
 		<alias old="chop" new="rtrim()"/>
 		<alias old="close" new="closedir()"/>
 		<alias old="die" new="exit()"/>
@@ -432,7 +432,7 @@
 	<!--  *********************************************  -->
 
 	<!-- Replace  methods -->
-	<test name="checkReplacements">
+	<test name="replacements">
 		<replacement old="$_POST" new="$this->input->post()"/>
 		<replacement old="$_GET" new="$this->input->get()"/>
 		<!-- <replacement old="$_SERVER" new="$this->input->server()"/>  -->

--- a/config/default.cfg.xml
+++ b/config/default.cfg.xml
@@ -187,16 +187,16 @@
 	are followed by a space before the opening parenthesis.
 	PEAR standard stipulates this to distinguish it from function calls.
 	-->
-	<test name="spaceAfterControlStmt"/>
+	<test name="spaceAfterControlStatement"/>
 
 	<!-- Check that there is no space after a function name in a function call -->
 	<test name="noSpaceAfterFunctionName" level="info"></test>
 
 	<!-- Check for the (required) presence of a white space after some tokens : "," "}" "-" -->
-	<test name="checkWhiteSpaceAfter"/>
+	<test name="whiteSpaceAfter"/>
 
 	<!-- Check for the (required) presence of a white space before some tokens : "{" "-" -->
-	<test name="checkWhiteSpaceBefore">
+	<test name="whiteSpaceBefore">
 		<exception value=":"/>  <!-- Because of the switch/case -->
 	</test>
 
@@ -213,7 +213,7 @@
 	<!-- Check that the lenght of the line doesn't pass the max value -->
 	<test name="lineLength" level="info">
 		<property name="maxLineLength" value="160"/>
-		<property name="checkHTMLLines" value="false"/>
+		<property name="htmlLines" value="false"/>
 	</test>
 
 	<!-- Checks that the lenght (in lines) of a function doesn't pass the max value -->
@@ -249,7 +249,7 @@
 
 	<!-- Check for prohibited functions -->
 	<!-- @see http://www.php.net/manual/en/indexes.php -->
-	<test name="checkProhibitedFunctions">
+	<test name="prohibitedFunctions">
 		<item value="echo"/>
 		<item value="system"/>
 		<item value="print_r"/>
@@ -271,7 +271,7 @@
 
 	<!-- Check for prohibited tokens -->
 	<!-- @see http://www.php.net/manual/en/tokens.php -->
-	<test name="checkProhibitedTokens">
+	<test name="prohibitedTokens">
 		<item value="T_BAD_CHARACTER"/>
 		<item value="T_DECLARE"/>
 		<item value="T_ENDDECLARE"/>
@@ -300,7 +300,7 @@
 	<test name="defaultValuesOrder"/>
 
 	<!-- Check for silenced errors before function calls (@function) -->
-	<test name="checkSilencedError">
+	<test name="silencedError">
 		<exception value="rename"/> <!-- Exceptions to this rule -->
 		<exception value="mkdir"/>
 		<exception value="chmod"/>
@@ -312,21 +312,21 @@
 	<!-- Avoid passing parameters by reference -->
 	<test name="avoidPassingReferences"/>
 
-	<test name="showTODOs"/>
+	<test name="showTodo"/>
 
 	<!-- Use boolean operators (&&) instead of logical operators (AND) -->
 	<test name="useBooleanOperators"/>
 
 	<!-- Check empty block like if ($a) {} -->
-	<test name="checkEmptyBlock">
+	<test name="emptyBlock">
 		<!--  <exception value="catch"/>  -->
 	</test>
 
 	<!-- Check empty statement ( ;; ) -->
-	<test name="checkEmptyStatement"/>
+	<test name="emptyStatement"/>
 
 	<!-- Check for the presence of heredoc -->
-	<test name="checkHeredoc"/>
+	<test name="heredoc"/>
 
 	<!-- Check for braces around code blocs (if, else, elseif, do, while, for, foreach) -->
 	<test name="needBraces"/>
@@ -344,7 +344,7 @@
 	Avoid using unary operators (++) inside a control statement
 	With the exception of for iterators, all variable incrementation or decrementation should occur in their own toplevel statement to increase readability.
 	-->
-	<test name="checkUnaryOperator">
+	<test name="unaryOperator">
 		<exception value="for"/>
 	</test>
 
@@ -352,7 +352,7 @@
 	With inner assignments it is difficult to see all places where a variable is set.
 	With the exception of for iterators, all assignments should occur in their own toplevel statement to increase readability.
 	-->
-	<test name="checkInnerAssignment">
+	<test name="innerAssignment">
 		<exception value="for"/>
 	</test>
 
@@ -360,23 +360,23 @@
 	<test name="oneClassPerFile"/>
 
 	<!-- Detect empty files -->
-	<test name="checkEmptyFile"/>
+	<test name="emptyFile"/>
 
 	<!--  ****************  -->
 	<!--      Unused        -->
 	<!--  ****************  -->
 
 	<!-- Detect unused private functions (detecting unused public ones is more difficult) -->
-	<test name="checkUnusedPrivateFunctions"/>
+	<test name="unusedPrivateFunctions"/>
 
 	<!-- Detect unused variables -->
-	<test name="checkUnusedVariables"/>
+	<test name="unusedVariables"/>
 
 	<!-- Detect unused function parameters -->
-	<test name="checkUnusedFunctionParameters"/>
+	<test name="unusedFunctionParameters"/>
 
 	<!-- Detect unused code (after return or throw) -->
-	<test name="checkUnusedCode"/>
+	<test name="unusedCode"/>
 
 	<!--  *******************  -->
 	<!--      Optimisation     -->
@@ -391,7 +391,7 @@
 	<!--  *******************  -->
 
 	<!-- Replace deprecated methods -->
-	<test name="checkDeprecation">
+	<test name="deprecation">
 		<deprecated old="call_user_method" new="call_user_func" version="4.1"/>
 		<deprecated old="call_user_method_array" new="call_user_func_array" version="4.1"/>
 		<deprecated old="define_syslog_variables" new="none" version="5.4"/>
@@ -442,7 +442,7 @@
 	<!--  *******************  -->
 
 	<!-- Replace deprecated methods -->
-	<test name="checkAliases">
+	<test name="aliases">
 		<alias old="chop" new="rtrim()"/>
 		<alias old="close" new="closedir()"/>
 		<alias old="die" new="exit()"/>

--- a/config/sameline.cfg.xml
+++ b/config/sameline.cfg.xml
@@ -158,16 +158,16 @@
 	are followed by a space before the opening parenthesis.
 	PEAR standard stipulates this to distinguish it from function calls.
 	-->
-	<test name="spaceAfterControlStmt"/>
+	<test name="spaceAfterControlStatement"/>
 
 	<!-- Check that there is no space after a function name in a function call -->
 	<test name="noSpaceAfterFunctionName" level="info"></test>
 
 	<!-- Check for the (required) presence of a white space after some tokens : "," "}" "-" -->
-	<test name="checkWhiteSpaceAfter"/>
+	<test name="whiteSpaceAfter"/>
 
 	<!-- Check for the (required) presence of a white space before some tokens : "{" "-" -->
-	<test name="checkWhiteSpaceBefore">
+	<test name="whiteSpaceBefore">
 		<exception value=":"/>  <!-- Because of the switch/case -->
 	</test>
 
@@ -184,7 +184,7 @@
 	<!-- Check that the lenght of the line doesn't pass the max value -->
 	<test name="lineLength" level="info">
 		<property name="maxLineLength" value="160"/>
-		<property name="checkHTMLLines" value="false"/>
+		<property name="htmlLines" value="false"/>
 	</test>
 
 	<!-- Checks that the lenght (in lines) of a function doesn't pass the max value -->
@@ -212,7 +212,7 @@
 
 	<!-- Check for prohibited functions -->
 	<!-- @see http://www.php.net/manual/en/indexes.php -->
-	<test name="checkProhibitedFunctions">
+	<test name="prohibitedFunctions">
 		<item value="echo"/>
 		<item value="system"/>
 		<item value="print_r"/>
@@ -234,7 +234,7 @@
 
 	<!-- Check for prohibited tokens -->
 	<!-- @see http://www.php.net/manual/en/tokens.php -->
-	<test name="checkProhibitedTokens">
+	<test name="prohibitedTokens">
 		<item value="T_BAD_CHARACTER"/>
 		<item value="T_DECLARE"/>
 		<item value="T_ENDDECLARE"/>
@@ -263,7 +263,7 @@
 	<test name="defaultValuesOrder"/>
 
 	<!-- Check for silenced errors before function calls (@function) -->
-	<test name="checkSilencedError">
+	<test name="silencedError">
 		<exception value="rename"/> <!-- Exceptions to this rule -->
 		<exception value="mkdir"/>
 		<exception value="chmod"/>
@@ -275,21 +275,21 @@
 	<!-- Avoid passing parameters by reference -->
 	<test name="avoidPassingReferences"/>
 
-	<test name="showTODOs"/>
+	<test name="showTodo"/>
 
 	<!-- Use boolean operators (&&) instead of logical operators (AND) -->
 	<test name="useBooleanOperators"/>
 
 	<!-- Check empty block like if ($a) {} -->
-	<test name="checkEmptyBlock">
+	<test name="emptyBlock">
 		<!--  <exception value="catch"/>  -->
 	</test>
 
 	<!-- Check empty statement ( ;; ) -->
-	<test name="checkEmptyStatement"/>
+	<test name="emptyStatement"/>
 
 	<!-- Check for the presence of heredoc -->
-	<test name="checkHeredoc"/>
+	<test name="heredoc"/>
 
 	<!-- Check for braces around code blocs (if, else, elseif, do, while, for, foreach) -->
 	<test name="needBraces"/>
@@ -307,7 +307,7 @@
 	Avoid using unary operators (++) inside a control statement
 	With the exception of for iterators, all variable incrementation or decrementation should occur in their own toplevel statement to increase readability.
 	-->
-	<test name="checkUnaryOperator">
+	<test name="unaryOperator">
 		<exception value="for"/>
 	</test>
 
@@ -315,7 +315,7 @@
 	With inner assignments it is difficult to see all places where a variable is set.
 	With the exception of for iterators, all assignments should occur in their own toplevel statement to increase readability.
 	-->
-	<test name="checkInnerAssignment">
+	<test name="innerAssignment">
 		<exception value="for"/>
 	</test>
 
@@ -323,23 +323,23 @@
 	<test name="oneClassPerFile"/>
 
 	<!-- Detect empty files -->
-	<test name="checkEmptyFile"/>
+	<test name="emptyFile"/>
 
 	<!--  ****************  -->
 	<!--      Unused        -->
 	<!--  ****************  -->
 
 	<!-- Detect unused private functions (detecting unused public ones is more difficult) -->
-	<test name="checkUnusedPrivateFunctions"/>
+	<test name="unusedPrivateFunctions"/>
 
 	<!-- Detect unused variables -->
-	<test name="checkUnusedVariables"/>
+	<test name="unusedVariables"/>
 
 	<!-- Detect unused function parameters -->
-	<test name="checkUnusedFunctionParameters"/>
+	<test name="unusedFunctionParameters"/>
 
 	<!-- Detect unused code (after return or throw) -->
-	<test name="checkUnusedCode"/>
+	<test name="unusedCode"/>
 
 	<!--  *******************  -->
 	<!--      Optimisation     -->
@@ -354,7 +354,7 @@
 	<!--  *******************  -->
 
 	<!-- Replace deprecated methods -->
-	<test name="checkDeprecation">
+	<test name="deprecation">
 		<deprecated old="call_user_method" new="call_user_func" version="4.1"/>
 		<deprecated old="call_user_method_array" new="call_user_func_array" version="4.1"/>
 		<deprecated old="define_syslog_variables" new="none" version="5.4"/>
@@ -405,7 +405,7 @@
 	<!--  *******************  -->
 
 	<!-- Replace deprecated methods -->
-	<test name="checkAliases">
+	<test name="aliases">
 		<alias old="chop" new="rtrim()"/>
 		<alias old="close" new="closedir()"/>
 		<alias old="die" new="exit()"/>

--- a/config/spaceindent.cfg.xml
+++ b/config/spaceindent.cfg.xml
@@ -158,18 +158,18 @@
 	are followed by a space before the opening parenthesis.
 	PEAR standard stipulates this to distinguish it from function calls.
 	-->
-	<test name="spaceAfterControlStmt"/>
+	<test name="spaceAfterControlStatement"/>
 
 	<!-- Check that there is no space after a function name in a function call -->
 	<test name="noSpaceAfterFunctionName" level="info"></test>
 
 	<!-- Check for the (required) presence of a white space after some tokens : "," "}" "-" -->
-	<test name="checkWhiteSpaceAfter">
+	<test name="whiteSpaceAfter">
 		<exception value="."/>  <!-- Exceptions to this rule -->
 	</test>
 
 	<!-- Check for the (required) presence of a white space before some tokens : "{" "-" -->
-	<test name="checkWhiteSpaceBefore">
+	<test name="whiteSpaceBefore">
 		<exception value="."/>  <!-- Exceptions to this rule -->
 		<exception value=":"/>  <!-- Because of the switch/case -->
 	</test>
@@ -187,7 +187,7 @@
 	<!-- Check that the lenght of the line doesn't pass the max value -->
 	<test name="lineLength" level="info">
 		<property name="maxLineLength" value="160"/>
-		<property name="checkHTMLLines" value="false"/>
+		<property name="htmlLines" value="false"/>
 	</test>
 
 	<!-- Checks that the lenght (in lines) of a function doesn't pass the max value -->
@@ -215,7 +215,7 @@
 
 	<!-- Check for prohibited functions -->
 	<!-- @see http://www.php.net/manual/en/indexes.php -->
-	<test name="checkProhibitedFunctions">
+	<test name="prohibitedFunctions">
 		<item value="echo"/>
 		<item value="system"/>
 		<item value="print_r"/>
@@ -237,7 +237,7 @@
 
 	<!-- Check for prohibited tokens -->
 	<!-- @see http://www.php.net/manual/en/tokens.php -->
-	<test name="checkProhibitedTokens">
+	<test name="prohibitedTokens">
 		<item value="T_BAD_CHARACTER"/>
 		<item value="T_DECLARE"/>
 		<item value="T_ENDDECLARE"/>
@@ -266,7 +266,7 @@
 	<test name="defaultValuesOrder"/>
 
 	<!-- Check for silenced errors before function calls (@function) -->
-	<test name="checkSilencedError">
+	<test name="silencedError">
 		<exception value="rename"/> <!-- Exceptions to this rule -->
 		<exception value="mkdir"/>
 		<exception value="chmod"/>
@@ -278,21 +278,21 @@
 	<!-- Avoid passing parameters by reference -->
 	<test name="avoidPassingReferences"/>
 
-	<test name="showTODOs"/>
+	<test name="showTodo"/>
 
 	<!-- Use boolean operators (&&) instead of logical operators (AND) -->
 	<test name="useBooleanOperators"/>
 
 	<!-- Check empty block like if ($a) {} -->
-	<test name="checkEmptyBlock">
+	<test name="emptyBlock">
 		<!--  <exception value="catch"/>  -->
 	</test>
 
 	<!-- Check empty statement ( ;; ) -->
-	<test name="checkEmptyStatement"/>
+	<test name="emptyStatement"/>
 
 	<!-- Check for the presence of heredoc -->
-	<test name="checkHeredoc"/>
+	<test name="heredoc"/>
 
 	<!-- Check for braces around code blocs (if, else, elseif, do, while, for, foreach) -->
 	<test name="needBraces"/>
@@ -310,7 +310,7 @@
 	Avoid using unary operators (++) inside a control statement
 	With the exception of for iterators, all variable incrementation or decrementation should occur in their own toplevel statement to increase readability.
 	-->
-	<test name="checkUnaryOperator">
+	<test name="unaryOperator">
 		<exception value="for"/>
 	</test>
 
@@ -318,7 +318,7 @@
 	With inner assignments it is difficult to see all places where a variable is set.
 	With the exception of for iterators, all assignments should occur in their own toplevel statement to increase readability.
 	-->
-	<test name="checkInnerAssignment">
+	<test name="innerAssignment">
 		<exception value="for"/>
 	</test>
 
@@ -326,23 +326,23 @@
 	<test name="oneClassPerFile"/>
 
 	<!-- Detect empty files -->
-	<test name="checkEmptyFile"/>
+	<test name="emptyFile"/>
 
 	<!--  ****************  -->
 	<!--      Unused        -->
 	<!--  ****************  -->
 
 	<!-- Detect unused private functions (detecting unused public ones is more difficult) -->
-	<test name="checkUnusedPrivateFunctions"/>
+	<test name="unusedPrivateFunctions"/>
 
 	<!-- Detect unused variables -->
-	<test name="checkUnusedVariables"/>
+	<test name="unusedVariables"/>
 
 	<!-- Detect unused function parameters -->
-	<test name="checkUnusedFunctionParameters"/>
+	<test name="unusedFunctionParameters"/>
 
 	<!-- Detect unused code (after return or throw) -->
-	<test name="checkUnusedCode"/>
+	<test name="unusedCode"/>
 
 	<!--  *******************  -->
 	<!--      Optimisation     -->
@@ -357,7 +357,7 @@
 	<!--  *******************  -->
 
 	<!-- Replace deprecated methods -->
-	<test name="checkDeprecation">
+	<test name="deprecation">
 		<deprecated old="call_user_method" new="call_user_func" version="4.1"/>
 		<deprecated old="call_user_method_array" new="call_user_func_array" version="4.1"/>
 		<deprecated old="define_syslog_variables" new="none" version="5.4"/>
@@ -408,7 +408,7 @@
 	<!--  *******************  -->
 
 	<!-- Replace deprecated methods -->
-	<test name="checkAliases">
+	<test name="aliases">
 		<alias old="chop" new="rtrim()"/>
 		<alias old="close" new="closedir()"/>
 		<alias old="die" new="exit()"/>

--- a/config/test.cfg.xml
+++ b/config/test.cfg.xml
@@ -158,18 +158,18 @@
 	are followed by a space before the opening parenthesis.
 	PEAR standard stipulates this to distinguish it from function calls.
 	-->
-	<test name="spaceAfterControlStmt"/>
+	<test name="spaceAfterControlStatement"/>
 
 	<!-- Check that there is no space after a function name in a function call -->
 	<test name="noSpaceAfterFunctionName" level="info"></test>
 
 	<!-- Check for the (required) presence of a white space after some tokens : "," "}" "-" -->
-	<test name="checkWhiteSpaceAfter">
+	<test name="whiteSpaceAfter">
 		<exception value="."/>  <!-- Exceptions to this rule -->
 	</test>
 
 	<!-- Check for the (required) presence of a white space before some tokens : "{" "-" -->
-	<test name="checkWhiteSpaceBefore">
+	<test name="whiteSpaceBefore">
 		<exception value="."/>  <!-- Exceptions to this rule -->
 		<exception value=":"/>  <!-- Because of the switch/case -->
 	</test>
@@ -187,7 +187,7 @@
 	<!-- Check that the lenght of the line doesn't pass the max value -->
 	<test name="lineLength" level="info">
 		<property name="maxLineLength" value="160"/>
-		<property name="checkHTMLLines" value="true"/>
+		<property name="htmlLines" value="true"/>
 	</test>
 
 	<!-- Checks that the lenght (in lines) of a function doesn't pass the max value -->
@@ -215,7 +215,7 @@
 
 	<!-- Check for prohibited functions -->
 	<!-- @see http://www.php.net/manual/en/indexes.php -->
-	<test name="checkProhibitedFunctions">
+	<test name="prohibitedFunctions">
 		<item value="echo"/>
 		<item value="system"/>
 		<item value="print_r"/>
@@ -237,7 +237,7 @@
 
 	<!-- Check for prohibited tokens -->
 	<!-- @see http://www.php.net/manual/en/tokens.php -->
-	<test name="checkProhibitedTokens">
+	<test name="prohibitedTokens">
 		<item value="T_BAD_CHARACTER"/>
 		<item value="T_DECLARE"/>
 		<item value="T_ENDDECLARE"/>
@@ -266,7 +266,7 @@
 	<test name="defaultValuesOrder"/>
 
 	<!-- Check for silenced errors before function calls (@function) -->
-	<test name="checkSilencedError">
+	<test name="silencedError">
 		<exception value="rename"/> <!-- Exceptions to this rule -->
 		<exception value="mkdir"/>
 		<exception value="chmod"/>
@@ -279,21 +279,21 @@
 	<!-- Avoid passing parameters by reference -->
 	<test name="avoidPassingReferences"/>
 
-	<test name="showTODOs"/>
+	<test name="showTodo"/>
 
 	<!-- Use boolean operators (&&) instead of logical operators (AND) -->
 	<test name="useBooleanOperators"/>
 
 	<!-- Check empty block like if ($a) {} -->
-	<test name="checkEmptyBlock">
+	<test name="emptyBlock">
 		<!--  <exception value="catch"/>  -->
 	</test>
 
 	<!-- Check empty statement ( ;; ) -->
-	<test name="checkEmptyStatement"/>
+	<test name="emptyStatement"/>
 
 	<!-- Check for the presence of heredoc -->
-	<test name="checkHeredoc"/>
+	<test name="heredoc"/>
 
 	<!-- Check for braces around code blocs (if, else, elseif, do, while, for, foreach) -->
 	<test name="needBraces"/>
@@ -311,7 +311,7 @@
 	Avoid using unary operators (++) inside a control statement
 	With the exception of for iterators, all variable incrementation or decrementation should occur in their own toplevel statement to increase readability.
 	-->
-	<test name="checkUnaryOperator">
+	<test name="unaryOperator">
 		<exception value="for"/>
 	</test>
 
@@ -319,7 +319,7 @@
 	With inner assignments it is difficult to see all places where a variable is set.
 	With the exception of for iterators, all assignments should occur in their own toplevel statement to increase readability.
 	-->
-	<test name="checkInnerAssignment">
+	<test name="innerAssignment">
 		<exception value="for"/>
 	</test>
 
@@ -331,16 +331,16 @@
 	<!--  ****************  -->
 
 	<!-- Detect unused private functions (detecting unused public ones is more difficult) -->
-	<test name="checkUnusedPrivateFunctions"/>
+	<test name="unusedPrivateFunctions"/>
 
 	<!-- Detect unused variables -->
-	<test name="checkUnusedVariables"/>
+	<test name="unusedVariables"/>
 
 	<!-- Detect unused function parameters -->
-	<test name="checkUnusedFunctionParameters"/>
+	<test name="unusedFunctionParameters"/>
 
 	<!-- Detect unused code (after return or throw) -->
-	<test name="checkUnusedCode"/>
+	<test name="unusedCode"/>
 
 	<!--  *******************  -->
 	<!--      Optimisation     -->
@@ -355,7 +355,7 @@
 	<!--  *******************  -->
 
 	<!-- Replace deprecated methods -->
-	<test name="checkDeprecation">
+	<test name="deprecation">
 		<deprecated old="call_user_method" new="call_user_func" version="4.1"/>
 		<deprecated old="call_user_method_array" new="call_user_func_array" version="4.1"/>
 		<deprecated old="define_syslog_variables" new="none" version="5.4"/>
@@ -406,7 +406,7 @@
 	<!--  *******************  -->
 
 	<!-- Replace deprecated methods -->
-	<test name="checkAliases">
+	<test name="aliases">
 		<alias old="chop" new="rtrim()"/>
 		<alias old="close" new="closedir()"/>
 		<alias old="die" new="exit()"/>

--- a/config/zend.cfg.xml
+++ b/config/zend.cfg.xml
@@ -167,18 +167,18 @@
 	are followed by a space before the opening parenthesis. PEAR standard stipulates
 	this to distinguish it from function calls.
 	-->
-	<test name="spaceAfterControlStmt" />
+	<test name="spaceAfterControlStatement" />
 
 	<!-- Check that there is no space after a function name in a function call -->
 	<test name="noSpaceAfterFunctionName" level="info"></test>
 
 	<!-- Check for the (required) presence of a white space after some tokens
 		: "," "}" "-" -->
-	<test name="checkWhiteSpaceAfter"/>
+	<test name="whiteSpaceAfter"/>
 
 	<!-- Check for the (required) presence of a white space before some tokens
 		: "{" "-" -->
-	<test name="checkWhiteSpaceBefore">
+	<test name="whiteSpaceBefore">
 		<exception value=":" />  <!-- Because of the switch/case -->
 	</test>
 
@@ -196,7 +196,7 @@
 	<!-- Check that the lenght of the line doesn't pass the max value -->
 	<test name="lineLength" level="info">
 		<property name="maxLineLength" value="120" />
-		<property name="checkHTMLLines" value="false" />
+		<property name="htmlLines" value="false" />
 	</test>
 
 	<!-- Checks that the lenght (in lines) of a function doesn't pass the max
@@ -225,7 +225,7 @@
 
 	<!-- Check for prohibited functions -->
 	<!-- @see http://www.php.net/manual/en/indexes.php -->
-	<test name="checkProhibitedFunctions">
+	<test name="prohibitedFunctions">
 		<item value="echo" />
 		<item value="system" />
 		<item value="print_r" />
@@ -247,7 +247,7 @@
 
 	<!-- Check for prohibited tokens -->
 	<!-- @see http://www.php.net/manual/en/tokens.php -->
-	<test name="checkProhibitedTokens">
+	<test name="prohibitedTokens">
 		<item value="T_BAD_CHARACTER" />
 		<item value="T_DECLARE" />
 		<item value="T_ENDDECLARE" />
@@ -276,7 +276,7 @@
 	<test name="defaultValuesOrder" />
 
 	<!-- Check for silenced errors before function calls (@function) -->
-	<test name="checkSilencedError">
+	<test name="silencedError">
 		<exception value="rename" /> <!-- Exceptions to this rule -->
 		<exception value="mkdir" />
 		<exception value="chmod" />
@@ -288,21 +288,21 @@
 	<!-- Avoid passing parameters by reference -->
 	<test name="avoidPassingReferences"/>
 
-	<test name="showTODOs"/>
+	<test name="showTodo"/>
 
 	<!-- Use boolean operators (&&) instead of logical operators (AND) -->
 	<test name="useBooleanOperators"/>
 
 	<!-- Check empty block like if ($a) {} -->
-	<test name="checkEmptyBlock">
+	<test name="emptyBlock">
 		<!-- <exception value="catch"/> -->
 	</test>
 
 	<!-- Check empty statement ( ;; ) -->
-	<test name="checkEmptyStatement"/>
+	<test name="emptyStatement"/>
 
 	<!-- Check for the presence of heredoc -->
-	<test name="checkHeredoc"/>
+	<test name="heredoc"/>
 
 	<!-- Check for braces around code blocs (if, else, elseif, do, while, for,
 		foreach) -->
@@ -320,14 +320,14 @@
 	<!-- Avoid using unary operators (++) inside a control statement With the
 		exception of for iterators, all variable incrementation or decrementation
 		should occur in their own toplevel statement to increase readability. -->
-	<test name="checkUnaryOperator">
+	<test name="unaryOperator">
 		<exception value="for" />
 	</test>
 
 	<!-- With inner assignments it is difficult to see all places where a variable
 		is set. With the exception of for iterators, all assignments should occur
 		in their own toplevel statement to increase readability. -->
-	<test name="checkInnerAssignment">
+	<test name="innerAssignment">
 		<exception value="for" />
 	</test>
 
@@ -340,19 +340,19 @@
 
 	<!-- Detect unused private functions (detecting unused public ones is more
 		difficult) -->
-	<test name="checkUnusedPrivateFunctions"/>
+	<test name="unusedPrivateFunctions"/>
 
 	<!-- Detect unused variables -->
-	<test name="checkUnusedVariables"/>
+	<test name="unusedVariables"/>
 
 	<!-- Detect unused function parameters -->
-	<test name="checkUnusedFunctionParameters"/>
+	<test name="unusedFunctionParameters"/>
 
 	<!-- Detect unused code (after return or throw) -->
-	<test name="checkUnusedCode"/>
+	<test name="unusedCode"/>
 
 	<!-- Detect empty files -->
-	<test name="checkEmptyFile"/>
+	<test name="emptyFile"/>
 
 	<!-- ******************* -->
 	<!-- Optimisation -->
@@ -367,7 +367,7 @@
 	<!-- ******************* -->
 
 	<!-- Replace deprecated methods -->
-	<test name="checkDeprecation">
+	<test name="deprecation">
 		<deprecated old="call_user_method" new="call_user_func"
 			version="4.1" />
 		<deprecated old="call_user_method_array" new="call_user_func_array"
@@ -444,7 +444,7 @@
 	<!-- ******************* -->
 
 	<!-- Replace deprecated methods -->
-	<test name="checkAliases">
+	<test name="aliases">
 		<alias old="chop" new="rtrim()" />
 		<alias old="close" new="closedir()" />
 		<alias old="die" new="exit()" />
@@ -472,7 +472,7 @@
 	<!--  *********************************************  -->
 
 	<!-- Replace  methods -->
-	<test name="checkReplacements">
+	<test name="replacements">
 		<replacement old="$_POST" new="$this->getRequest()->getPost()"/>
 		<replacement old="$_GET" new="$this->getRequest()->getParam()"/>
 	</test>


### PR DESCRIPTION
Saner check names consist of dropping all `check` prefixes and making a few names a bit more verbose.