### PR TITLE
Convert level name to lower case 

### DIFF
--- a/src/PHPCheckstyle/Config/CheckStyleConfig.php
+++ b/src/PHPCheckstyle/Config/CheckStyleConfig.php
@@ -69,7 +69,7 @@ abstract class CheckStyleConfig {
 		$test = strtolower($test);
 
 		if (array_key_exists($test, $this->config) && array_key_exists('level', $this->config[$test])) {
-			$ret = $this->config[$test]['level'];
+			$ret = strtolower($this->config[$test]['level']);
 		}
 
 		$invalidLevels = array(ERROR, IGNORE, INFO, WARNING);


### PR DESCRIPTION
Convert level name to lower case to support older configs where levels are specified in upper case. After an upgrade from an older version of phpcheckstyle, all checks caused the "Invalid level for test" message. This request helps all our builds and hopefully benefits others.
