### PR TITLE
Added a exit code appropriate to the error count.

### DIFF
--- a/run.php
+++ b/run.php
@@ -175,5 +175,5 @@ if (!$options['quiet']) {
  	echo "=======" . PHP_EOL . PHP_EOL;
  	echo "Reporting Completed." . PHP_EOL;
 }
-
-exit(0);
+$exitCode = $errorCounts[ERROR] > 0?1:0; 
+exit($exitCode);


### PR DESCRIPTION
With this change, we can use the PHPCheckStyle with travis or any Integration system that check the exit code to check if the script succeeded or failed.