### PR TITLE
Add level Flag

### DIFF
--- a/run.php
+++ b/run.php
@@ -35,6 +35,9 @@ function usage() {
 		"--lang" =>
 			"[Optional] Language file to use for the result (en-us by default).",
 
+        "--level" =>
+            "[Optional] Specifies the output level (info, warning, error). For console report only.",
+
 		"--quiet" =>
 			"[Optional] Quiet mode.",
 
@@ -94,6 +97,11 @@ for ($i = 1; $i < $_SERVER["argc"]; $i ++) {
 			$i++;
 			$options['lang'] = $_SERVER['argv'][$i];
 			break;
+
+        case "--level":
+            $i++;
+            $options['level'] = $_SERVER['argv'][$i];
+            break;
 
 		case "--config":
 			$i++;
@@ -167,9 +175,25 @@ if (!empty($options['linecount'])) {
 if ($options['time']) {
 	$time_start = microtime();
 }
+$level = INFO;
+if (isset($options['level'])) {
+    switch ($options['level']) {
+        case INFO:
+            $level = INFO;
+            break;
+        case WARNING:
+            $level = WARNING;
+            break;
+        case ERROR:
+            $level = ERROR;
+            break;
+        default:
+            echo "Unkown level '" . $options['level'] . "'. Ingnoring level'\n";
+    }
+}
 
 
-$style = new PHPCheckstyle\PHPCheckstyle($formats, $options['outdir'], $options['config'], $lineCountFile, $options['debug'], $options['progress']);
+$style = new PHPCheckstyle\PHPCheckstyle($formats, $options['outdir'], $options['config'], $lineCountFile, $options['debug'], $options['progress'], $level);
 
 if (file_exists(__DIR__ . '/src/PHPCheckstyle/Lang/' . $options['lang'] . '.ini')) {
 	$style->setLang($options['lang']);

--- a/src/PHPCheckstyle/PHPCheckstyle.php
+++ b/src/PHPCheckstyle/PHPCheckstyle.php
@@ -67,6 +67,8 @@ class PHPCheckstyle {
 	// Language for messages
 	private $lang;
 
+	private $level;
+
 	private $messages = array();
 
 	// Files to ignore
@@ -307,7 +309,7 @@ class PHPCheckstyle {
 	 *        	indicate if we log the progress of the scan
 	 * @access public
 	 */
-	public function __construct($formats, $outDir, $configFile, $linecountfile = null, $debug = false, $progress = false) {
+	public function __construct($formats, $outDir, $configFile, $linecountfile = null, $debug = false, $progress = false, $level = INFO) {
 
 		// Initialise the Tokenizer
 		$this->tokenizer = new Tokenizer();
@@ -316,6 +318,9 @@ class PHPCheckstyle {
 		$this->statementStack = new StatementStack();
 
 		$this->debug = $debug;
+
+		// Reporting Level
+		$this->level = $level;
 
 		// Initialise the Reporters
 		$this->_reporter = new Reporters();
@@ -335,7 +340,7 @@ class PHPCheckstyle {
 			$this->_reporter->addReporter(new XmlConsoleFormatReporter());
 		}
 		if (in_array("console", $formats)) {
-			$this->_reporter->addReporter(new ConsoleReporter());
+			$this->_reporter->addReporter(new ConsoleReporter($this->level));
 		}
 		if (in_array("array", $formats)) {
 			$this->_reporter->addReporter(new ArrayReporter());

--- a/src/PHPCheckstyle/Reporter/ConsoleReporter.php
+++ b/src/PHPCheckstyle/Reporter/ConsoleReporter.php
@@ -10,7 +10,18 @@ namespace PHPCheckstyle\Reporter;
  * ================================
  */
 class ConsoleReporter extends Reporter {
-	/**
+
+    /**
+     * @var String
+     */
+    private $reportingLevel;
+
+    public function __construct($level = INFO) {
+        $this->reportingLevel = $this->calculateLevel($level);
+        parent::__construct();
+    }
+
+    /**
 	 * {@inheritdoc}
 	 *
 	 * @param Integer $line
@@ -24,6 +35,37 @@ class ConsoleReporter extends Reporter {
 	 * @SuppressWarnings
 	 */
 	public function writeError($line, $check, $message, $level = WARNING) {
-		echo "File \"" . $this->currentPhpFile . "\"" . " " . $level . ", line " . $line . " - " . $message . "\n";
+	    $messageLevel = $this->calculateLevel($level);
+	    if ($messageLevel >= $this->reportingLevel) {
+            echo "File \"" . $this->currentPhpFile . "\"" . " " . $level . ", line " . $line . " - " . $message . "\n";
+        }
 	}
+
+    /**
+     * Transforms a specified level from a String to an Integer
+     * so one can check if the level is above or below a
+     * certain threshold.
+     *
+     * Unknown level will return 1 which is equal to INFO
+     *
+     * @param String $level
+     *
+     * @return int
+     *          INFO = 1
+     *          WARNING = 2
+     *          ERROR = 3
+     *          unknown = 1
+     */
+	private function calculateLevel($level) {
+	    switch ($level) {
+            case INFO:
+                return 1;
+            case WARNING:
+                return 2;
+            case ERROR:
+                return 3;
+            default:
+                return 1;
+        }
+    }
 }


### PR DESCRIPTION
I added a Flag (--level [error,warning,info]), so the level of output can be configured when using the console format.

closes #74 