### PR TITLE
Fix square closing array

### DIFF
--- a/src/PHPCheckstyle/PHPCheckstyle.php
+++ b/src/PHPCheckstyle/PHPCheckstyle.php
@@ -1343,7 +1343,8 @@ class PHPCheckstyle {
 		if ($this->statementStack->getCurrentStackItem()->openParentheses === 0) {
 
 			// We are in a array declaration, we unstack
-			if ($this->statementStack->getCurrentStackItem()->type === StatementItem::TYPE_ARRAY) {
+			if ($this->statementStack->getCurrentStackItem()->type === StatementItem::TYPE_ARRAY AND 
+				$this->statementStack->getCurrentStackItem()->name !== 'square_bracket_open') {
 				$this->statementStack->pop();
 			}
 		}


### PR DESCRIPTION
Pass this test case for indentation with spaces

    /**
     * Test.
     */
    public function foo() {

        $bVar = array(
            'x' => 'y',
            'z' => $this->check()
        );

        $cVar = [
            'x' => 'y',
            'z' => $this->check()
        ];

        unset($bVar, $cVar);
    }