### PR TITLE
Bug Fix - fail to detect private functions with spaces after function…

### DIFF
--- a/src/PHPCheckstyle/PHPCheckstyle.php
+++ b/src/PHPCheckstyle/PHPCheckstyle.php
@@ -1346,7 +1346,7 @@ class PHPCheckstyle {
 		if ($this->statementStack->getCurrentStackItem()->openParentheses === 0) {
 
 			// We are in a array declaration, we unstack
-			if ($this->statementStack->getCurrentStackItem()->type === StatementItem::TYPE_ARRAY AND 
+			if ($this->statementStack->getCurrentStackItem()->type === StatementItem::TYPE_ARRAY AND
 				$this->statementStack->getCurrentStackItem()->name !== 'square_bracket_open') {
 				$this->statementStack->pop();
 			}
@@ -2228,7 +2228,7 @@ class PHPCheckstyle {
 			if ($currentToken->id === T_STRING) {
 				$nameDetected = $currentToken->text;
 			}
-			$curlyOpeningDetected = $this->tokenizer->checkNextToken(T_PARENTHESIS_OPEN);
+			$curlyOpeningDetected = $this->tokenizer->checkNextValidToken(T_PARENTHESIS_OPEN);
 		}
 
 		// currentToken should end up being the function name token

--- a/src/PHPCheckstyle/PHPCheckstyle.php
+++ b/src/PHPCheckstyle/PHPCheckstyle.php
@@ -2582,8 +2582,8 @@ class PHPCheckstyle {
 	 * This function is launched when the current token is T_ENCAPSED_AND_WHITESPACE.
 	 */
 	private function _checkEncapsedVariablesInsideString() {
-		if ($this->_isActive('encapsedVariablesInsideString') AND !$this->statementStack->getCurrentStackItem()->inHeredoc
-		    OR ($this->_inFuncCall AND !$this->_config->isException('encapsedVariablesInsideString', end($this->_currentFuncCall)))) {
+		if ($this->_isActive('encapsedVariablesInsideString') AND (!$this->statementStack->getCurrentStackItem()->inHeredoc
+		    OR ($this->_inFuncCall AND !$this->_config->isException('encapsedVariablesInsideString', end($this->_currentFuncCall))))) {
 			$this->_writeError('encapsedVariablesInsideString', $this->_getMessage('VARIABLE_INSIDE_STRING'));
 		}
 	}


### PR DESCRIPTION
I debugged the _processFunctionStatement function and found out the reason for not detecting private function is the use of checkNextToken instead of checkNextValidToken. This caused whitespace to be the name of a private function instead of the real name if there is a space between function name and the open parenthesis. This fix solves the issue.