### PR TITLE
i add max-errors parameter

### DIFF
--- a/run.php
+++ b/run.php
@@ -34,6 +34,9 @@ function usage() {
 
 		"--lang" =>
 			"[Optional] Language file to use for the result (en-us by default).",
+		
+		"--max-errors" =>
+			"[Optional] Defines how many errors are still allowed for a pass (0 by default)",
 
         "--level" =>
             "[Optional] Specifies the output level (info, warning, error). For console report only.",
@@ -68,6 +71,7 @@ $options['progress'] = false;
 $options['lang'] = 'en-us';
 $options['quiet'] = false;
 $options['time'] = false;
+$options['max-errors'] = 0;
 $lineCountFile = null;
 
 // loop through user input
@@ -98,10 +102,10 @@ for ($i = 1; $i < $_SERVER["argc"]; $i ++) {
 			$options['lang'] = $_SERVER['argv'][$i];
 			break;
 
-        case "--level":
-            $i++;
-            $options['level'] = $_SERVER['argv'][$i];
-            break;
+		case "--level":
+		        $i++;
+		        $options['level'] = $_SERVER['argv'][$i];
+		        break;
 
 		case "--config":
 			$i++;
@@ -167,6 +171,10 @@ if (!$options['src']) {
 	echo "\nPlease specify a source directory/file using --src option.\n\n";
 	usage();
 }
+if (!$options['max-errors']) {
+	echo "\nPlease specify a number when using --max-errors option.\n\n";
+	usage();
+}
 
 if (!empty($options['linecount'])) {
 	$lineCountFile = "ncss.xml";
@@ -222,8 +230,5 @@ if (!$options['quiet']) {
 
 }
 
-
-
-
-$exitCode = ($errorCounts[ERROR] > 0) ? 1 : 0;
+$exitCode = ($errorCounts[ERROR] > $options['max-errors']) ? 1 : 0;
 exit($exitCode);

--- a/run.php
+++ b/run.php
@@ -111,13 +111,18 @@ for ($i = 1; $i < $_SERVER["argc"]; $i ++) {
 			$i++;
 			$options['config'] = $_SERVER['argv'][$i];
 			break;
-
+			
 		case "--debug":
 			$options['debug'] = true;
 			break;
 
 		case "--linecount":
 			$options['linecount'] = true;
+			break;
+			
+		case "--max-errors":
+			$i++;
+			$options['max-errors'] = $_SERVER['argv'][$i];
 			break;
 
 		case "--progress":


### PR DESCRIPTION
As a user I would like to define how many errors are allowed in the system, so I can slowly use phpcheckstyle as CI testing. And work my way down instead of being forced to first fix all errors and then implement phpcheckstyle as CI testing.