### PR TITLE
Add no space after control stmt test option

### DIFF
--- a/src/PHPCheckstyle/PHPCheckstyle.php
+++ b/src/PHPCheckstyle/PHPCheckstyle.php
@@ -1817,6 +1817,13 @@ class PHPCheckstyle {
 					$this->_writeError('spaceAfterControlStmt', $msg);
 				}
 			}
+		} elseif ($this->_isActive('noSpaceAfterControlStmt')) { // first token: if one whitespace, error
+			if ($this->tokenizer->checkNextToken(T_WHITESPACE)) {
+				if (($token->id !== T_ELSE) && ($token->id !== T_TRY) && ($token->id !== T_DO)) {
+					$msg = $this->_getMessage('NO_SPACE_AFTER_TOKEN', $csText);
+					$this->_writeError('noSpaceAfterControlStmt', $msg);
+				}
+			}
 		}
 
 		// for some control structures like "else" and "do",

--- a/test/IndentationTest.php
+++ b/test/IndentationTest.php
@@ -150,5 +150,34 @@ class IndentationTest extends TestCase {
 		$this->assertEquals(2, $errorCounts['info'], 'We expect 2 info');
 		$this->assertEquals(7, $errorCounts['warning'], 'We expect 7 warnings');
 	}
+
+    /**
+     * Test for space after control statement (no space after control statement).
+     */
+    public function testBadSpaceAfterControl() {
+        $phpcheckstyle = $GLOBALS['PHPCheckstyle'];
+
+        // Change the configuration to check for no spaces after control statement
+        $config = $phpcheckstyle->getConfig();
+
+		$refl = new \ReflectionProperty($config, 'config');
+        $refl->setAccessible(true);
+        $value = $refl->getValue($config);
+
+        unset($value['spaceaftercontrolstmt']);
+        $value['nospaceaftercontrolstmt'] = array();
+        $refl->setValue($config, $value);
+
+		$phpcheckstyle->processFiles(array(
+			'./test/sample/bad_space_after_control.php'
+		));
+
+		$errorCounts = $phpcheckstyle->getErrorCounts();
+
+		$this->assertEquals(0, $errorCounts['error'], 'We expect 0 errors');
+		$this->assertEquals(0, $errorCounts['ignore'], 'We expect 0 ignored checks');
+		$this->assertEquals(0, $errorCounts['info'], 'We expect 0 info');
+		$this->assertEquals(1, $errorCounts['warning'], 'We expect 1 warning');
+    }
 }
 ?>

--- a/test/sample/bad_space_after_control.php
+++ b/test/sample/bad_space_after_control.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is an exemple of PHP file containing bad spacing around control statement.
+ * This file should generate 1 warning.
+ *
+ * @SuppressWarnings localScopeVariableLength
+ */
+class Space {
+
+	/**
+	 * Test spacing
+	 *
+	 * @param String $a
+	 * @param String $b
+	 * @return String
+	 */
+	function testSpaces($a, $b) {
+		if ($a === null) { // 1 - noSpaceAfterControlStmt (if statement)
+			return $b;
+		}
+	}
+
+}


### PR DESCRIPTION
As a user I should be able to do the exact opposite of the PEAR standard convention - to do no space after a control statement token.

This PR adds a new option `noSpaceAfterControlStmt`, which is the exact opposite of `spaceAfterControlStmt`.

I wasn't sure how to properly add the test as the test suite setup is very weird and unusual.

Please forgive the usage of Reflection, if you know of an option to add the config without relying on Reflection, please tell me and I'll adjust the code. I haven't found a way to adjust the check configuration with the exposed API.

If you have any other issues with the code style (or if there's any better way), feel free to comment on it.